### PR TITLE
Enhancement: NAFNet can take any input shapes now

### DIFF
--- a/restorers/model/nafnet/nafnet.py
+++ b/restorers/model/nafnet/nafnet.py
@@ -243,7 +243,7 @@ class NAFNet(keras.models.Model):
         # Crop back to the original size
         return x[:, :H, :W, :]
 
-    def fix_input_shape(self, inputs):
+    def fix_input_shape(self, inputs: tf.Tensor) -> tf.Tensor:
         """
         Fixes input shape for NAFNet
         This is because NAFNet can only work with images whose shape is

--- a/restorers/model/nafnet/nafnet.py
+++ b/restorers/model/nafnet/nafnet.py
@@ -212,7 +212,6 @@ class NAFNet(keras.models.Model):
         return channels
 
     def call(self, inputs: tf.Tensor, *args, **kwargs) -> tf.Tensor:
-
         _, H, W, _ = inputs.shape
 
         # Scale the image to the next nearest multiple of self.expected_image_scale

--- a/restorers/tests/model/nafnet/test_nafnet.py
+++ b/restorers/tests/model/nafnet/test_nafnet.py
@@ -74,12 +74,47 @@ class SimpleGateTest(unittest.TestCase):
 
 
 class NAFNetTest(unittest.TestCase):
+    def setUp(self):
+        self.input_shapes = [
+            (1, 254, 254, 3),
+            (1, 255, 255, 3),
+            (1, 257, 257, 3),
+            (1, 258, 258, 3),
+            (1, 400, 600, 3),
+        ]
+
+        self.reshaped_shapes = [
+            (1, 256, 256, 3),
+            (1, 256, 256, 3),
+            (1, 272, 272, 3),
+            (1, 272, 272, 3),
+            (1, 400, 608, 3),
+        ]
+
     def test_nafnet(self) -> None:
         input_shape = (1, 256, 256, 3)
         x = tf.ones(input_shape)
         nafnet = NAFNet()
         y = nafnet(x)
         self.assertEqual(y.shape, x.shape)
+
+    def test_varying_input_shape(self) -> None:
+        for input_shape in self.input_shapes:
+            x = tf.ones(input_shape)
+            nafnet = NAFNet()
+            y = nafnet(x)
+            self.assertEqual(y.shape, x.shape)
+
+    def test_input_reshaping(self) -> None:
+        for input_shape, reshaped_shapes in zip(
+            self.input_shapes, self.reshaped_shapes
+        ):
+            x = tf.ones(input_shape)
+            nafnet = NAFNet(
+                encoder_block_nums=[1, 1, 1, 1], decoder_block_nums=[1, 1, 1, 1]
+            )
+            y = nafnet.fix_input_shape(x)
+            self.assertEqual(y.shape, reshaped_shapes)
 
 
 class PixelShuffleTest(unittest.TestCase):


### PR DESCRIPTION
Fixes #49 

Changes proposed by this PR :-
 As NAFNet follows a UNet architecture, the input must be a multiple of 2^(no. encoder blocks) . If the input is not of the expected shape, then the input is padded to the next multiple of 2^(no. encoder blocks). Inspired from https://github.com/megvii-research/NAFNet/blob/main/basicsr/models/archs/NAFNet_arch.py check_input_size method.

The only concern I have is, whether tf.pad is differentiable. I think it should be. @soumik12345 , @SauravMaheshkar  please comment. Other than that, we should be good to go.

Request for Review: @soumik12345, @SauravMaheshkar 
